### PR TITLE
Wait longer before killing and relaunching pelias-data-container

### DIFF
--- a/pelias-data-container/dc.yaml
+++ b/pelias-data-container/dc.yaml
@@ -55,7 +55,7 @@ items:
                 - bash
                 - '-c'
                 - 'curl localhost:9200/pelias/_search?q=* | grep -v error'
-            initialDelaySeconds: 240
+            initialDelaySeconds: 360
             timeoutSeconds: 30
             periodSeconds: 10
           readinessProbe:


### PR DESCRIPTION
4 minutes is not enough to launch ElasticSearch with pelias data, and
deployment kept on looping htrough launch - wait 4 min - kill actions.
Wait time increased to 6 minutes.
