### PR TITLE
Grant more memory and cpu load for pelias-api

### DIFF
--- a/pelias-api/dc.yaml
+++ b/pelias-api/dc.yaml
@@ -62,10 +62,10 @@ items:
             protocol: TCP
           resources:
             requests:
-              cpu: 100m
-              memory: 800Mi
+              cpu: 200m
+              memory: 1500Mi
             limits:
-              memory: 800Mi
+              memory: 1500Mi
     test: false
     triggers:
     - type: ConfigChange

--- a/pelias-data-container/dc.yaml
+++ b/pelias-data-container/dc.yaml
@@ -75,9 +75,9 @@ items:
           resources:
             requests:
               cpu: 1000m
-              memory: 1500Mi
+              memory: 3000Mi
             limits:
-              memory: 1500Mi
+              memory: 3000Mi
           volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: pelias-data-container-volume-1


### PR DESCRIPTION
The new libpostal parser increases need of resources significantly
